### PR TITLE
Fix missing return statement in DBMSDO.getKV()

### DIFF
--- a/src/dbms/index.ts
+++ b/src/dbms/index.ts
@@ -86,7 +86,7 @@ export class DBMSDO extends DurableObject<Env> {
 	}
 
 	async getKV(key: string): Promise<Primitive | undefined> {
-		await this.ctx.storage.get<Primitive>(`USER-${key}`);
+		return await this.ctx.storage.get<Primitive>(`USER-${key}`);
 	}
 
 	async sql(params: DOSqlQuery): Promise<any> {


### PR DESCRIPTION
## Summary

- Adds missing `return` keyword in `DBMSDO.getKV()` method (`src/dbms/index.ts:89`)
- The method was awaiting `this.ctx.storage.get()` but never returning the result, so it always returned `undefined`
- This impacts the migration system in `src/dbms/configs/index.ts:26` which calls `getKV` to read the last run migration index — without the return, it always falls back to `0`, potentially re-running already-applied migrations

## Change

```diff
 async getKV(key: string): Promise<Primitive | undefined> {
-    await this.ctx.storage.get<Primitive>(`USER-${key}`);
+    return await this.ctx.storage.get<Primitive>(`USER-${key}`);
 }
```

## Test plan

- [x] Verified the fix is a single-word addition (`return`) with no side effects
- [x] Confirmed `getKV` is used in the migration config system and the missing return causes it to always default to `0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)