### PR TITLE
Fix missing await in DeleteDatabase.handle()

### DIFF
--- a/src/api/endpoints/deleteDatabase.ts
+++ b/src/api/endpoints/deleteDatabase.ts
@@ -24,7 +24,7 @@ export class DeleteDatabase extends OpenAPIRoute {
 
 		await stub.destroy();
 
-		const result = configDatabase.sql({
+		const result = await configDatabase.sql({
 			query: "DELETE FROM databases WHERE id = ? RETURNING *",
 			arguments: [data.params.database_id],
 		});


### PR DESCRIPTION
## Summary

- Adds missing `await` keyword on the `configDatabase.sql()` call in `DeleteDatabase.handle()` (`src/api/endpoints/deleteDatabase.ts:27`)
- Without `await`, the `result` variable holds a Promise object which gets serialized as `{}` in the JSON response, so the client never sees the actual DELETE query results
- All other endpoints (`CreateDatabase`, `ListDatabases`, `QueryDatabase`, `StatsDatabase`) correctly `await` their async calls — this was the only one missing it

## Change

```diff
- const result = configDatabase.sql({
+ const result = await configDatabase.sql({
```

## Test plan

- [x] Verified all other endpoints use `await` for the same pattern
- [x] Project builds successfully with `npm run build`
- [x] Single-word fix with no side effects

🤖 Generated with [Claude Code](https://claude.com/claude-code)