### PR TITLE
Fix WebSocket hang when waiting for locked database

### DIFF
--- a/src/dbms/index.ts
+++ b/src/dbms/index.ts
@@ -200,7 +200,7 @@ export class DBMSDO extends DurableObject<Env> {
 							if (this.isLocked() && wsSessionId !== this.sessionIdInPower) {
 
 								console.log('db locked: waiting')
-								await this.awaitUntil(_ => this.isLocked() === 1)
+								await this.awaitUntil(_ => !this.isLocked())
 							}
 
 							const queries = message.request.stmt.query.split(';').map((q) => q.trim().toLowerCase())


### PR DESCRIPTION
## Summary

- Fixes a bug in `src/dbms/index.ts:203` where `this.isLocked() === 1` uses strict equality (`===`) to compare a boolean with a number
- In JavaScript, `true === 1` evaluates to `false`, so this condition **never resolves**, causing the `awaitUntil` polling loop to run forever
- This hangs WebSocket connections indefinitely when a client tries to execute a query while the database is locked by another session's transaction

## Change

```diff
- await this.awaitUntil(_ => this.isLocked() === 1)
+ await this.awaitUntil(_ => !this.isLocked())
```

The fix changes the condition to `!this.isLocked()` so it correctly waits until the database is unlocked before proceeding.

## Context

`isLocked()` returns `this.locked === 1`, which is a **boolean**. Comparing that boolean with `=== 1` (strict equality against a number) always returns `false` regardless of the locked state. The intent is to wait until the lock is released, so `!this.isLocked()` is the correct condition.

## Test plan

- [x] Verified `isLocked()` returns a boolean (line 41-43)
- [x] Confirmed `true === 1` is `false` in JavaScript strict equality
- [x] Project builds successfully with `npm run build`
- [x] Single-line fix with no side effects

🤖 Generated with [Claude Code](https://claude.com/claude-code)