### PR TITLE
Fix typos in WebSocket transaction error messages

### DIFF
--- a/src/dbms/index.ts
+++ b/src/dbms/index.ts
@@ -227,14 +227,14 @@ export class DBMSDO extends DurableObject<Env> {
 									if (!this.isLocked()) {
 										return {
 											type: "response_error",
-											error: "no transaction is progress to commit",
+											error: "no transaction in progress to commit",
 										}
 									}
 
 									if (wsSessionId !== this.sessionIdInPower) {
 										return {
 											type: "response_error",
-											error: "your session cannot commit another one transaction",
+											error: "your session cannot commit another session's transaction",
 										}
 									}
 
@@ -252,14 +252,14 @@ export class DBMSDO extends DurableObject<Env> {
 									if (!this.isLocked()) {
 										return {
 											type: "response_error",
-											error: "no transaction is progress to rollback",
+											error: "no transaction in progress to rollback",
 										}
 									}
 
 									if (wsSessionId !== this.sessionIdInPower) {
 										return {
 											type: "response_error",
-											error: "your session cannot rollback another one transaction",
+											error: "your session cannot rollback another session's transaction",
 										}
 									}
 


### PR DESCRIPTION
## Summary

- Fixes 4 typos in error messages returned by the WebSocket transaction handling code in `src/dbms/index.ts`

## Changes

**"is progress" → "in progress"** (lines 230, 255):
```diff
- "no transaction is progress to commit"
+ "no transaction in progress to commit"

- "no transaction is progress to rollback"
+ "no transaction in progress to rollback"
```

**"another one transaction" → "another session's transaction"** (lines 237, 262):
```diff
- "your session cannot commit another one transaction"
+ "your session cannot commit another session's transaction"

- "your session cannot rollback another one transaction"
+ "your session cannot rollback another session's transaction"
```

## Why

These error messages are surfaced to clients via WebSocket responses. Correcting the grammar makes the errors clearer and more professional.

## Test plan

- [x] `npm run build` passes successfully
- [x] String-only changes with no behavioral side effects

🤖 Generated with [Claude Code](https://claude.com/claude-code)