### PR TITLE
Fix potential crash in stats() when parsing table SQL definitions

### DIFF
--- a/src/dbms/index.ts
+++ b/src/dbms/index.ts
@@ -135,11 +135,10 @@ export class DBMSDO extends DurableObject<Env> {
 						  and tbl_name not like '_cf%';`,
 			})
 		).results.map((obj) => {
-			const columns = obj.sql
-				.split("(")[1]
-				.split(")")[0]
-				.split(",")
-				.map((col: string) => col.trim().replaceAll('"', "").split(" ")[0]);
+			const sqlBody = obj.sql?.split("(")?.[1]?.split(")")?.[0];
+			const columns = sqlBody
+				? sqlBody.split(",").map((col: string) => col.trim().replaceAll('"', "").split(" ")[0])
+				: [];
 
 			return {
 				...obj,


### PR DESCRIPTION
## Summary

- Fixes unsafe string splitting in `DBMSDO.stats()` (`src/dbms/index.ts`) that can crash with a `TypeError` when a table's SQL definition is null or doesn't contain expected parentheses
- Uses optional chaining (`?.`) to safely handle null/undefined at each parsing step, falling back to an empty columns array instead of crashing

## Problem

The `stats()` method queries `sqlite_master` and parses each table's `CREATE TABLE` SQL using chained `.split()` calls:

```typescript
const columns = obj.sql
    .split("(")[1]     // undefined if obj.sql is null or has no "("
    .split(")")[0]     // TypeError: Cannot read properties of undefined
    ...
```

If `obj.sql` is null or doesn't contain parentheses, `split("(")[1]` returns `undefined`, and the subsequent `.split(")")` call throws:

> `TypeError: Cannot read properties of undefined (reading 'split')`

## Fix

```diff
- const columns = obj.sql
-     .split("(")[1]
-     .split(")")[0]
-     .split(",")
-     .map((col: string) => col.trim().replaceAll('"', "").split(" ")[0]);
+ const sqlBody = obj.sql?.split("(")?.[1]?.split(")")?.[0];
+ const columns = sqlBody
+     ? sqlBody.split(",").map((col: string) => col.trim().replaceAll('"', "").split(" ")[0])
+     : [];
```

## Test plan

- [x] `npm run build` passes successfully
- [x] Single expression change with no behavioral side effects for valid SQL definitions
- [x] Tables with null/malformed SQL now return an empty `columns` array instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)